### PR TITLE
check before running captureStackTrace

### DIFF
--- a/lib/cuvva-error.js
+++ b/lib/cuvva-error.js
@@ -15,7 +15,9 @@ function CuvvaError(code, reasons, meta) {
 	}
 
 	CuvvaError.super_(code);
-	Error.captureStackTrace(this, this.constructor);
+
+	if (Error.captureStackTrace)
+		Error.captureStackTrace(this, this.constructor);
 
 	this.code = code;
 	this.reasons = reasons;


### PR DESCRIPTION
This little lib is used by both node and frontend, and because some browser might not implement captureStackTrace, it will throw an exception, badly.

This PR is meant to safe check / fix this call and make it safe for the web 🕷🕸👌 